### PR TITLE
feat: 국내 주식을 조회한 결과를 DB에 저장하는 기능에 대한 테스트 구현

### DIFF
--- a/src/main/java/com/bigant/gaeme/dao/StockDao.java
+++ b/src/main/java/com/bigant/gaeme/dao/StockDao.java
@@ -1,12 +1,11 @@
 package com.bigant.gaeme.dao;
 
 import com.bigant.gaeme.dao.dto.KrStockDto;
-import java.net.URISyntaxException;
 import java.util.List;
 
 public interface StockDao {
 
-    List<KrStockDto> getStock() throws URISyntaxException;
+    List<KrStockDto> getStock();
 
     List<KrStockDto> getEtf();
 

--- a/src/main/java/com/bigant/gaeme/repository/KrStockRepository.java
+++ b/src/main/java/com/bigant/gaeme/repository/KrStockRepository.java
@@ -1,0 +1,13 @@
+package com.bigant.gaeme.repository;
+
+import com.bigant.gaeme.repository.entity.KrStock;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KrStockRepository extends JpaRepository<KrStock, Long> {
+
+    List<KrStock> findAllBySymbolIn(List<String> symbols);
+
+}

--- a/src/main/java/com/bigant/gaeme/repository/entity/Stock.java
+++ b/src/main/java/com/bigant/gaeme/repository/entity/Stock.java
@@ -1,12 +1,17 @@
 package com.bigant.gaeme.repository.entity;
 
+import com.bigant.gaeme.repository.enums.StockType;
 import jakarta.persistence.DiscriminatorColumn;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
+import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,6 +34,7 @@ public abstract class Stock {
 
     private String symbol;
 
-    private String type;
+    @Enumerated(value = EnumType.STRING)
+    private StockType type;
 
 }

--- a/src/main/java/com/bigant/gaeme/repository/enums/StockType.java
+++ b/src/main/java/com/bigant/gaeme/repository/enums/StockType.java
@@ -1,0 +1,18 @@
+package com.bigant.gaeme.repository.enums;
+
+import lombok.Data;
+import lombok.Getter;
+
+@Getter
+public enum StockType {
+
+    STOCK("stock"),
+    ETF("etf");
+
+    StockType(String name) {
+        this.name = name;
+    }
+
+    private final String name;
+
+}

--- a/src/main/java/com/bigant/gaeme/service/StockDataService.java
+++ b/src/main/java/com/bigant/gaeme/service/StockDataService.java
@@ -1,0 +1,71 @@
+package com.bigant.gaeme.service;
+
+import com.bigant.gaeme.dao.StockDao;
+import com.bigant.gaeme.dao.dto.KrStockDto;
+import com.bigant.gaeme.repository.KrStockRepository;
+import com.bigant.gaeme.repository.entity.KrStock;
+import com.bigant.gaeme.repository.enums.StockType;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StockDataService {
+
+    private final StockDao krStockDao;
+
+    private final KrStockRepository krStockRepository;
+
+    @Scheduled(cron = "* * 23 * * 3")
+    @Transactional
+    public void saveData() {
+        saveStockData(krStockDao::getStock, StockType.STOCK);
+        saveStockData(krStockDao::getEtf, StockType.ETF);
+    }
+
+    private void saveStockData(Supplier<List<KrStockDto>> dataFunc, StockType type) {
+        List<KrStockDto> newStocks = dataFunc.get();
+        Set<KrStockDto> exists = krStockRepository.findAll().stream()
+                .filter(stock -> stock.getType() == type)
+                .map(this::toKrStockDto)
+                .collect(Collectors.toSet());
+        List<KrStockDto> addStocks = newStocks.stream().filter(item -> !exists.contains(item)).toList();
+        List<KrStockDto> delistingStocks = exists.stream().filter(item -> !newStocks.contains(item)).toList();
+
+        krStockRepository.saveAll(addStocks.stream().map(stock -> toKrStock(stock, false, type)).toList());
+
+        delistStocks(delistingStocks);
+    }
+
+    private void delistStocks(List<KrStockDto> stocks) {
+        List<KrStock> delistingStocks = krStockRepository.findAllBySymbolIn(stocks.stream().map(KrStockDto::getShortenCode).toList());
+
+        delistingStocks.forEach(delistingStock -> delistingStock.setDelisting(true));
+
+        krStockRepository.saveAll(delistingStocks);
+    }
+
+    private KrStockDto toKrStockDto(KrStock stock) {
+        return KrStockDto.builder()
+                .name(stock.getName())
+                .shortenCode(stock.getSymbol())
+                .isinCode(stock.getIsinCode()).build();
+    }
+
+    private KrStock toKrStock(KrStockDto dto, boolean isDelisting, StockType type) {
+        return KrStock.builder()
+                .name(dto.getName())
+                .symbol(dto.getShortenCode())
+                .isinCode(dto.getIsinCode())
+                .isDelisting(isDelisting)
+                .type(type)
+                .build();
+    }
+
+}

--- a/src/test/java/com/bigant/gaeme/repository/entity/KrStockTest.java
+++ b/src/test/java/com/bigant/gaeme/repository/entity/KrStockTest.java
@@ -2,6 +2,7 @@ package com.bigant.gaeme.repository.entity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.bigant.gaeme.repository.enums.StockType;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("NonAsciiCharacters")
@@ -11,12 +12,12 @@ public class KrStockTest {
     void krStock_생성_테스트() {
         //given, when
         KrStock result = KrStock.builder().id(1L).isDelisting(true).isinCode("abc").symbol("1234").name("name")
-                .type("ETF")
+                .type(StockType.ETF)
                 .build();
 
         //then
         assertEquals(KrStock.builder().id(1L).isDelisting(true).isinCode("abc").symbol("1234").name("name")
-                .type("ETF")
+                .type(StockType.ETF)
                 .build(), result);
     }
 

--- a/src/test/java/com/bigant/gaeme/service/StockDataServiceTest.java
+++ b/src/test/java/com/bigant/gaeme/service/StockDataServiceTest.java
@@ -1,0 +1,180 @@
+package com.bigant.gaeme.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.bigant.gaeme.dao.KrStockDao;
+import com.bigant.gaeme.dao.dto.KrStockDto;
+import com.bigant.gaeme.repository.KrStockRepository;
+import com.bigant.gaeme.repository.entity.KrStock;
+import com.bigant.gaeme.repository.enums.StockType;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+@Transactional
+@ExtendWith(MockitoExtension.class)
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class StockDataServiceTest {
+
+    @Autowired
+    private KrStockRepository krStockRepository;
+
+    private KrStockDao krStockDao;
+
+    private StockDataService stockDataService;
+
+    @BeforeEach
+    void setup() {
+        krStockDao = Mockito.mock(KrStockDao.class);
+        stockDataService = new StockDataService(krStockDao, krStockRepository);
+    }
+
+    @Test
+    void 기존_데이터_없을때_주식_데이터_저장_테스트() {
+        //given
+        Mockito.doReturn(List.of(KrStockDto.builder()
+                .name("stock")
+                .shortenCode("abc")
+                .isinCode("abcd")
+                .build())).when(krStockDao).getStock();
+        Mockito.doReturn(List.of(KrStockDto.builder()
+                .name("etf")
+                .shortenCode("def")
+                .isinCode("defg")
+                .build())).when(krStockDao).getEtf();
+
+        //when
+        stockDataService.saveData();
+        List<KrStock> result = krStockRepository.findAll();
+
+        //then
+        assertEquals(
+                List.of(
+                        KrStock.builder()
+                                .id(result.get(0).getId())
+                                .name("stock")
+                                .symbol("abc")
+                                .isinCode("abcd")
+                                .type(StockType.STOCK)
+                                .isDelisting(false)
+                                .build(),
+                        KrStock.builder()
+                                .id(result.get(1).getId())
+                                .name("etf")
+                                .symbol("def")
+                                .isinCode("defg")
+                                .type(StockType.ETF)
+                                .isDelisting(false)
+                                .build()
+                ),
+                result
+        );
+    }
+
+    @Test
+    void 기존_데이터_존재할때_데이터_추가() {
+        //given
+        krStockRepository.save(KrStock.builder()
+                .name("stock1")
+                .isinCode("abc")
+                .symbol("abc")
+                .isDelisting(false)
+                .type(StockType.STOCK)
+                .build());
+        Mockito.doReturn(List.of(KrStockDto.builder()
+                        .name("stock2")
+                        .shortenCode("def")
+                        .isinCode("defg")
+                        .build(),
+                KrStockDto.builder()
+                        .name("stock1")
+                        .isinCode("abc")
+                        .shortenCode("abc")
+                        .build()
+        )).when(krStockDao).getStock();
+
+        //when
+        stockDataService.saveData();
+        List<KrStock> result = krStockRepository.findAll();
+
+
+        //then
+        assertEquals(
+                List.of(
+                        KrStock.builder()
+                                .id(result.get(0).getId())
+                                .name("stock1")
+                                .symbol("abc")
+                                .isinCode("abc")
+                                .type(StockType.STOCK)
+                                .isDelisting(false)
+                                .build(),
+                        KrStock.builder()
+                                .id(result.get(1).getId())
+                                .name("stock2")
+                                .symbol("def")
+                                .isinCode("defg")
+                                .type(StockType.STOCK)
+                                .isDelisting(false)
+                                .build()
+                ),
+                result
+        );
+    }
+
+    @Test
+    void 기존_데이터_존재할때_상장폐지_되는_경우() {
+        //given
+        krStockRepository.save(KrStock.builder()
+                .name("stock1")
+                .isinCode("abc")
+                .symbol("abc")
+                .isDelisting(false)
+                .type(StockType.STOCK)
+                .build());
+        Mockito.doReturn(List.of(KrStockDto.builder()
+                        .name("stock2")
+                        .shortenCode("def")
+                        .isinCode("defg")
+                        .build()
+        )).when(krStockDao).getStock();
+
+        //when
+        stockDataService.saveData();
+        List<KrStock> result = krStockRepository.findAll();
+
+        //then
+        assertEquals(
+                List.of(
+                        KrStock.builder()
+                                .id(result.get(0).getId())
+                                .name("stock1")
+                                .symbol("abc")
+                                .isinCode("abc")
+                                .type(StockType.STOCK)
+                                .isDelisting(true)
+                                .build(),
+                        KrStock.builder()
+                                .id(result.get(1).getId())
+                                .name("stock2")
+                                .symbol("def")
+                                .isinCode("defg")
+                                .type(StockType.STOCK)
+                                .isDelisting(false)
+                                .build()
+                ),
+                result
+        );
+    }
+
+
+}


### PR DESCRIPTION
### 관련 문서
https://www.notion.so/66421698a02e45cf963f3d70920e65eb

### 개발 내용
- KrStockRepository 구현
  - 주식 symbols를 기준으로 주식을 검색하는 메서드 구현(findAllBySymbolIn)
- StockDataService 구현
  - 주식과 ETF를 조회한 정보를 DB에 저장하는 메서드 구현 (saveData)

- https://github.com/K-BigAnt/Back/pull/14 의존성이 있음.
- https://github.com/K-BigAnt/Back/pull/13 의존성이 있음.

### 이슈번호
resolve #9
