### PR TITLE
refactor: 국내 주식, 미국 주식 관련 Dto의 부모 클래스 StockDto 구현 및 StockDao에 제네릭 적용

### DIFF
--- a/src/main/java/com/bigant/gaeme/dao/StockDao.java
+++ b/src/main/java/com/bigant/gaeme/dao/StockDao.java
@@ -1,12 +1,12 @@
 package com.bigant.gaeme.dao;
 
-import com.bigant.gaeme.dao.dto.KrStockDto;
+import com.bigant.gaeme.dao.dto.StockDto;
 import java.util.List;
 
-public interface StockDao {
+public interface StockDao<T extends StockDto> {
 
-    List<KrStockDto> getStock();
+    List<T> getStock();
 
-    List<KrStockDto> getEtf();
+    List<T> getEtf();
 
 }

--- a/src/main/java/com/bigant/gaeme/dao/dto/KrStockDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/KrStockDto.java
@@ -5,21 +5,18 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
-public class KrStockDto {
-
-    @JsonProperty("srtnCd")
-    private String shortenCode;
+@SuperBuilder
+public class KrStockDto extends StockDto {
 
     @JsonProperty("isinCd")
     private String isinCode;
-
-    @JsonProperty("itmsNm")
-    private String name;
 
 }

--- a/src/main/java/com/bigant/gaeme/dao/dto/StockDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/StockDto.java
@@ -1,0 +1,21 @@
+package com.bigant.gaeme.dao.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Data
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public abstract class StockDto {
+
+    @JsonAlias({"itmsNm", "name"})
+    private String name;
+
+    @JsonAlias({"srtnCd", "symbol"})
+    private String symbol;
+
+}

--- a/src/main/java/com/bigant/gaeme/dao/dto/StockDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/StockDto.java
@@ -12,7 +12,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public abstract class StockDto {
 
-    @JsonAlias({"itmsNm", "name"})
+    @JsonAlias({"itmsNm", "name", "companyName"})
     private String name;
 
     @JsonAlias({"srtnCd", "symbol"})

--- a/src/main/java/com/bigant/gaeme/dao/dto/UsEtfDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/UsEtfDto.java
@@ -5,7 +5,9 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @AllArgsConstructor
@@ -13,11 +15,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UsEtfDto {
 
+    @EqualsAndHashCode(callSuper = true)
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    @Builder
-    public static class UsEtfItem {
+    @SuperBuilder
+    public static class UsEtfItem extends StockDto {
 
         private String symbol;
 

--- a/src/main/java/com/bigant/gaeme/dao/dto/UsStockDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/UsStockDto.java
@@ -21,10 +21,6 @@ public class UsStockDto {
     @SuperBuilder
     public static class UsStockItem extends StockDto {
 
-        private String symbol;
-
-        private String name;
-
         private String country;
 
     }

--- a/src/main/java/com/bigant/gaeme/dao/dto/UsStockDto.java
+++ b/src/main/java/com/bigant/gaeme/dao/dto/UsStockDto.java
@@ -4,7 +4,9 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor
@@ -12,11 +14,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UsStockDto {
 
+    @EqualsAndHashCode(callSuper = true)
     @Data
     @AllArgsConstructor
     @NoArgsConstructor
-    @Builder
-    public static class UsStockItem {
+    @SuperBuilder
+    public static class UsStockItem extends StockDto {
 
         private String symbol;
 

--- a/src/main/java/com/bigant/gaeme/service/StockDataService.java
+++ b/src/main/java/com/bigant/gaeme/service/StockDataService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StockDataService {
 
-    private final StockDao krStockDao;
+    private final StockDao<KrStockDto> krStockDao;
 
     private final KrStockRepository krStockRepository;
 
@@ -44,7 +44,7 @@ public class StockDataService {
     }
 
     private void delistStocks(List<KrStockDto> stocks) {
-        List<KrStock> delistingStocks = krStockRepository.findAllBySymbolIn(stocks.stream().map(KrStockDto::getShortenCode).toList());
+        List<KrStock> delistingStocks = krStockRepository.findAllBySymbolIn(stocks.stream().map(KrStockDto::getSymbol).toList());
 
         delistingStocks.forEach(delistingStock -> delistingStock.setDelisting(true));
 
@@ -54,14 +54,14 @@ public class StockDataService {
     private KrStockDto toKrStockDto(KrStock stock) {
         return KrStockDto.builder()
                 .name(stock.getName())
-                .shortenCode(stock.getSymbol())
+                .symbol(stock.getSymbol())
                 .isinCode(stock.getIsinCode()).build();
     }
 
     private KrStock toKrStock(KrStockDto dto, boolean isDelisting, StockType type) {
         return KrStock.builder()
                 .name(dto.getName())
-                .symbol(dto.getShortenCode())
+                .symbol(dto.getSymbol())
                 .isinCode(dto.getIsinCode())
                 .isDelisting(isDelisting)
                 .type(type)

--- a/src/test/java/com/bigant/gaeme/dao/KrStockDaoTest.java
+++ b/src/test/java/com/bigant/gaeme/dao/KrStockDaoTest.java
@@ -23,7 +23,7 @@ public class KrStockDaoTest {
         KrStockDto stock = KrStockDto.builder()
                 .isinCode("KR7000020008")
                 .name("동화약품")
-                .shortenCode("A000020")
+                .symbol("A000020")
                 .build();
 
         //when
@@ -39,7 +39,7 @@ public class KrStockDaoTest {
         KrStockDto etf = KrStockDto.builder()
                 .isinCode("KR7069500007")
                 .name("KODEX 200")
-                .shortenCode("069500")
+                .symbol("069500")
                 .build();
 
         //when

--- a/src/test/java/com/bigant/gaeme/dao/dto/KrStockDtoTest.java
+++ b/src/test/java/com/bigant/gaeme/dao/dto/KrStockDtoTest.java
@@ -38,7 +38,7 @@ public class KrStockDtoTest {
         assertEquals(KrStockDto.builder()
                 .name("동화약품")
                 .isinCode("KR7000020008")
-                .shortenCode("A000020").build(), result);
+                .symbol("A000020").build(), result);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class KrStockDtoTest {
         assertEquals(KrStockDto.builder()
                 .name("KODEX 반도체")
                 .isinCode("KR7091160002")
-                .shortenCode("091160").build(), result);
+                .symbol("091160").build(), result);
     }
 
 }

--- a/src/test/java/com/bigant/gaeme/dao/dto/UsEtfDtoTest.java
+++ b/src/test/java/com/bigant/gaeme/dao/dto/UsEtfDtoTest.java
@@ -20,7 +20,7 @@ public class UsEtfDtoTest {
     }
 
     @Test
-:wq:    void 미국_ETF_Json_파싱() throws JsonProcessingException {
+    void 미국_Etf_Json_파싱() throws JsonProcessingException {
         String json = """
                 {
                     "data": {

--- a/src/test/java/com/bigant/gaeme/dao/dto/UsEtfDtoTest.java
+++ b/src/test/java/com/bigant/gaeme/dao/dto/UsEtfDtoTest.java
@@ -20,7 +20,7 @@ public class UsEtfDtoTest {
     }
 
     @Test
-    void 미국_Etf_Json_파싱() throws JsonProcessingException {
+:wq:    void 미국_ETF_Json_파싱() throws JsonProcessingException {
         String json = """
                 {
                     "data": {

--- a/src/test/java/com/bigant/gaeme/service/StockDataServiceTest.java
+++ b/src/test/java/com/bigant/gaeme/service/StockDataServiceTest.java
@@ -43,12 +43,12 @@ public class StockDataServiceTest {
         //given
         Mockito.doReturn(List.of(KrStockDto.builder()
                 .name("stock")
-                .shortenCode("abc")
+                .symbol("abc")
                 .isinCode("abcd")
                 .build())).when(krStockDao).getStock();
         Mockito.doReturn(List.of(KrStockDto.builder()
                 .name("etf")
-                .shortenCode("def")
+                .symbol("def")
                 .isinCode("defg")
                 .build())).when(krStockDao).getEtf();
 
@@ -92,13 +92,13 @@ public class StockDataServiceTest {
                 .build());
         Mockito.doReturn(List.of(KrStockDto.builder()
                         .name("stock2")
-                        .shortenCode("def")
+                        .symbol("def")
                         .isinCode("defg")
                         .build(),
                 KrStockDto.builder()
                         .name("stock1")
                         .isinCode("abc")
-                        .shortenCode("abc")
+                        .symbol("abc")
                         .build()
         )).when(krStockDao).getStock();
 
@@ -143,7 +143,7 @@ public class StockDataServiceTest {
                 .build());
         Mockito.doReturn(List.of(KrStockDto.builder()
                         .name("stock2")
-                        .shortenCode("def")
+                        .symbol("def")
                         .isinCode("defg")
                         .build()
         )).when(krStockDao).getStock();


### PR DESCRIPTION
- Dao에서 반환 값의 타입을 제한하기 위해 공통으로 상속받는 클래스(StockDto) 생성함.
- Dao에서는 구체적인 타입을 반환해야 하기 때문에 StockDao 인터페이스에 제네릭 적용