### PR TITLE
feat: OAuth 요청 API 구현

### DIFF
--- a/src/docs/asciidoc/auth.adoc
+++ b/src/docs/asciidoc/auth.adoc
@@ -1,0 +1,6 @@
+== Auth
+
+=== 인가코드 요청
+operation::auth/get[snippets="http-request,path-parameters,query-parameters"]
+==== redirect_uri에 code 쿼리 파라미터로 인가 코드가 전달됩니다.
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,3 +5,4 @@
 :toclevels: 2
 
 include::temp.adoc[]
+include::auth.adoc[]

--- a/src/main/java/com/bigant/gaeme/config/GaemeConfig.java
+++ b/src/main/java/com/bigant/gaeme/config/GaemeConfig.java
@@ -1,14 +1,13 @@
 package com.bigant.gaeme.config;
 
-import com.bigant.gaeme.dao.KrStockDao;
-import com.bigant.gaeme.dao.UsStockDao;
+import com.bigant.gaeme.dao.OauthClient;
 import com.bigant.gaeme.repository.KrStockRepository;
 import com.bigant.gaeme.repository.UsStockRepository;
 import com.bigant.gaeme.repository.entity.KrStock;
 import com.bigant.gaeme.repository.entity.UsStock;
 import com.bigant.gaeme.usecase.StockDataUsecase;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,6 +27,50 @@ public class GaemeConfig {
     @Bean
     public StockDataUsecase<KrStock, KrStockRepository> krStockDataUsecase() {
         return new StockDataUsecase<>(krStockRepository);
+    }
+
+    @Bean
+    public OauthClient kakaoOauthClient(
+            @Value("${oauth.kakao.base_url}") String baseUrl,
+            @Value("${oauth.kakao.client_id}") String clientId,
+            @Value("${oauth.kakao.auth_path}") String authPath
+    ) {
+        return new OauthClient(
+                baseUrl,
+                clientId,
+                authPath,
+                null
+        );
+    }
+
+    @Bean
+    public OauthClient naverOauthClient(
+            @Value("${oauth.naver.base_url}") String baseUrl,
+            @Value("${oauth.naver.client_id}") String clientId,
+            @Value("${oauth.naver.auth_path}") String authPath
+    ) {
+        return new OauthClient(
+                baseUrl,
+                clientId,
+                authPath,
+                null
+        );
+    }
+
+    @Bean
+    public OauthClient googleOauthClient(
+            @Value("${oauth.google.base_url}") String baseUrl,
+            @Value("${oauth.google.client_id}") String clientId,
+            @Value("${oauth.google.auth_path}") String authPath,
+            @Value("${oauth.google.scope}") String scope
+
+    ) {
+        return new OauthClient(
+                baseUrl,
+                clientId,
+                authPath,
+                scope
+        );
     }
 
 }

--- a/src/main/java/com/bigant/gaeme/config/SecurityConfig.java
+++ b/src/main/java/com/bigant/gaeme/config/SecurityConfig.java
@@ -15,7 +15,7 @@ public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/*", "/").permitAll()
+                        .requestMatchers("/*", "/", "/v1/auth/*/*", "/v1/auth/*").permitAll()
                         .anyRequest().authenticated())
                 .sessionManagement(sessionManagement -> sessionManagement
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/bigant/gaeme/config/WebConfig.java
+++ b/src/main/java/com/bigant/gaeme/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.bigant.gaeme.config;
+
+import com.bigant.gaeme.repository.enums.AuthCorp;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToAuthCorpConverter());
+    }
+
+    static class StringToAuthCorpConverter implements Converter<String, AuthCorp> {
+
+        @Override
+        public AuthCorp convert(String source) {
+            return AuthCorp.valueOf(source.toUpperCase());
+        }
+
+    }
+
+}

--- a/src/main/java/com/bigant/gaeme/controller/OauthController.java
+++ b/src/main/java/com/bigant/gaeme/controller/OauthController.java
@@ -1,0 +1,37 @@
+package com.bigant.gaeme.controller;
+
+import com.bigant.gaeme.repository.enums.AuthCorp;
+import com.bigant.gaeme.service.OauthService;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class OauthController {
+
+    private final OauthService oauthService;
+
+    @GetMapping("/{auth_corp}")
+    public void authorize(
+            @PathVariable("auth_corp") AuthCorp authCorp,
+            @RequestParam("redirect_uri") String redirectUri,
+            HttpServletResponse response
+    ) {
+        redirectToAuthPage(response, oauthService.getAuthUri(redirectUri, authCorp));
+    }
+
+    private void redirectToAuthPage(HttpServletResponse response, String authUri) {
+        try {
+            response.sendRedirect(authUri);
+        } catch (Exception e) {
+            throw new IllegalStateException("OAuth 인증에 실패했습니다.", e);
+        }
+    }
+
+}

--- a/src/main/java/com/bigant/gaeme/dao/OauthClient.java
+++ b/src/main/java/com/bigant/gaeme/dao/OauthClient.java
@@ -1,0 +1,24 @@
+package com.bigant.gaeme.dao;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class OauthClient {
+
+    private final String baseUrl;
+
+    private final String clientId;
+
+    private final String authPath;
+
+    private final String scope;
+
+    public URI getAuthUri(String redirectUri) {
+        String uriString = String.format("%s?client_id=%s&response_type=%s&redirect_uri=%s&scope=%s",
+                this.baseUrl + this.authPath, this.clientId, "code", redirectUri, this.scope);
+
+        return URI.create(uriString);
+    }
+
+}

--- a/src/main/java/com/bigant/gaeme/repository/enums/AuthCorp.java
+++ b/src/main/java/com/bigant/gaeme/repository/enums/AuthCorp.java
@@ -1,0 +1,17 @@
+package com.bigant.gaeme.repository.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AuthCorp {
+    KAKAO("kakao"),
+    NAVER("naver"),
+    GOOGLE("google");
+
+    AuthCorp(String name) {
+        this.name = name;
+    }
+
+    private final String name;
+
+}

--- a/src/main/java/com/bigant/gaeme/service/OauthService.java
+++ b/src/main/java/com/bigant/gaeme/service/OauthService.java
@@ -1,0 +1,26 @@
+package com.bigant.gaeme.service;
+
+import com.bigant.gaeme.dao.OauthClient;
+import com.bigant.gaeme.repository.enums.AuthCorp;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OauthService {
+
+    private final OauthClient kakaoOauthClient;
+
+    private final OauthClient naverOauthClient;
+
+    private final OauthClient googleOauthClient;
+
+    public String getAuthUri(String redirectUri, AuthCorp authCorp) {
+        return switch (authCorp) {
+            case KAKAO -> kakaoOauthClient.getAuthUri(redirectUri).toString();
+            case NAVER -> naverOauthClient.getAuthUri(redirectUri).toString();
+            case GOOGLE -> googleOauthClient.getAuthUri(redirectUri).toString();
+        };
+    }
+
+}

--- a/src/test/java/com/bigant/gaeme/controller/OauthControllerTest.java
+++ b/src/test/java/com/bigant/gaeme/controller/OauthControllerTest.java
@@ -1,0 +1,72 @@
+package com.bigant.gaeme.controller;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bigant.gaeme.repository.enums.AuthCorp;
+import com.bigant.gaeme.service.OauthService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(OauthController.class)
+@AutoConfigureMockMvc
+@AutoConfigureRestDocs(uriPort = 80)
+@ExtendWith(RestDocumentationExtension.class)
+public class OauthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private OauthService oauthService;
+
+    @Test
+    @WithMockUser
+    public void getAuthCodeTest() throws Exception {
+        BDDMockito.given(oauthService.getAuthUri("http://localhost/auth/callback", AuthCorp.KAKAO))
+                .willReturn("http://localhost/oauth/authorize?client_id=kakao_id&response_type=code&redirect_uri=http://localhost/auth/callback");
+
+        mockMvc.perform(RestDocumentationRequestBuilders.get("http://localhost/v1/auth/{auth_corp}", "kakao")
+                        .param("redirect_uri", "http://localhost/auth/callback"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(MockMvcResultMatchers.redirectedUrl(
+            "http://localhost/oauth/authorize?client_id=kakao_id&response_type=code&redirect_uri=http://localhost/auth/callback"
+                ))
+                .andDo(getAuthGetResultHandler())
+                .andDo(print());
+    }
+
+    private RestDocumentationResultHandler getAuthGetResultHandler() {
+        return document("auth/get",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                pathParameters(
+                        parameterWithName("auth_corp").description("OAuth 플랫폼 (kakao, naver, google)")
+                ),
+                queryParameters(
+                        parameterWithName("redirect_uri").description("인가코드를 받을 리다이렉트 URI")
+                )
+        );
+    }
+
+
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://localhost:3306/gaeme
+    url: jdbc:mariadb://localhost:3305/gaeme
     username: root
     password: root
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,33 @@
+server.port: 80
+
+spring:
+  application.name: gaeme
+
+  datasource:
+    driver-class-name: org.mariadb.jdbc.Driver
+    url: jdbc:mariadb://localhost:3306/gaeme
+    username: root
+    password: root
+
+  jpa:
+    hibernate:
+      ddl-auto: create  # option type: create, create-drop, update, validate, none
+    properties:
+      hibernate:
+        show_sql: true  # sql 쿼리를 보여줍니다.
+        format_sql: true  # sql query formatting
+
+stock:
+  data:
+    kr.api_key: apikey
+
+oauth:
+  kakao:
+    base_url: https://kauth.kakao.com
+    client_id: kakao_id
+    auth_path: /oauth/authorize
+  naver:
+    base_url: https://nid.naver.com
+    client_id: naver_id
+    clinet_secret: naver_secret
+    auth_path: /oauth2.0/authorize

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -31,3 +31,9 @@ oauth:
     client_id: naver_id
     clinet_secret: naver_secret
     auth_path: /oauth2.0/authorize
+  google:
+    base_url: https://accounts.google.com
+    client_id: google_id
+    client_secret: google_secret
+    auth_path: /o/oauth2/v2/auth
+    scope: https://www.googleapis.com/auth/drive.metadata.readonly


### PR DESCRIPTION
<!-- 이번 PR에서 작업한 내용을 자세히 설명해주세요.-->

## 관련 문서
https://www.notion.so/eb4825c2b5db4038b9e369bf146dec0e

## 연관된 이슈
<!--ex) 연관 이슈 : #1, #3
resolves #10-->
- resolve #27 

## 작업 내용
- `GET /v1/auth/{auth_corp}?redirect_url={url}` 구현

### 스크린샷
<img width="1015" alt="스크린샷 2024-08-07 오후 6 33 33" src="https://github.com/user-attachments/assets/a0a0d197-016f-4b90-865f-3ef6bd10d509">


## 추가 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?-->
- redirect_uri를 클라로 바로 가게 할수밖에 없는 구조인거 같더라고요..? 서버에서 받고 다시 주려고 했는데 먼가 많이 복잡해지는거 같아서 그냥 클라로 바로 보내게 했습니다.


<!-- 풀리퀘 작성 후 아래의 사항을 확인해주세요.
1. Reviewer를 등록했나요?
2. Assignee를 등록했나요?
3. Labels에 관련된 라벨을 모두 등록했나요?
4. MileStone이 있다면 등록했나요?
-->

